### PR TITLE
[240618] DB 초기화 오류 수정

### DIFF
--- a/docker/supabase/init.sql
+++ b/docker/supabase/init.sql
@@ -66,7 +66,7 @@ create table progress (
   id serial primary key,
   user_id int not null references users(id),
   video_id int not null references videos(id),
-  current_time int default 0,
+  current_seconds int default 0,
   is_completed boolean default false,
   updated_at timestamp default current_timestamp
 );


### PR DESCRIPTION
<!--
머지 제목은 항상 다음과 같은 규칙을 지킨다.
[날짜] 해당 Merge와 관련된 큰 제목
ex) [240806] 학습한 강의 수 저장 기능
머지 내용은 아래 템플릿을 복사해서 사용한다.
-->

### PR 타입

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- `init.sql` 내 `proress` 테이블의 `current_time` 필드를 `current_seconds`로 수정
(PostgreSQL 예약어 충돌로 인한 오류 수정)
### 전달 사항
- git pull --rebase origin main 실행 필수
