### PR TITLE
[240717] 검색 페이지 추가 및 프론트/백엔드 연동

### DIFF
--- a/client/src/components/pages/search/search.css
+++ b/client/src/components/pages/search/search.css
@@ -1,0 +1,187 @@
+/* ---------- 검색 페이지 레이아웃 ---------- */
+
+/* 검색 페이지 전체 박스 */
+.search-wrapper {
+  width: 100%;
+  min-height: 100vh;
+  background: linear-gradient(to bottom, #ffffff, #f0f9ff);
+  padding: 40px 16px;
+  box-sizing: border-box;
+}
+
+/* 섹션 제목 (크리에이터, 강의 등) */
+.search-title {
+  font-size: 24px;
+  font-weight: 700;
+  margin-bottom: 20px;
+  color: #333;
+}
+
+/* 크리에이터(강사) 카드 영역 */
+.creator-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 20px;
+  margin-bottom: 48px;
+}
+
+/* 카테고리 필터 버튼 영역 */
+.search-category-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 32px;
+}
+
+/* 개별 카테고리 버튼 */
+.category-btn {
+  padding: 8px 16px;
+  border-radius: 20px;
+  background: #f7f7f7;
+  color: #333;
+  font-weight: 500;
+  font-size: 14px;
+  cursor: pointer;
+  border: none;
+  transition: all 0.2s ease;
+}
+
+/* 선택된 카테고리 강조 */
+.category-btn.active {
+  background: #5c3df3;
+  color: #fff;
+}
+
+/* 강의 카드 그리드 */
+.lecture-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 20px;
+}
+
+/* 검색 결과 없을 때 안내 */
+.empty-search {
+  width: 100%;
+  min-height: 200px;
+  padding: 40px 20px;
+  background-color: #fafafa;
+  border: 2px dashed #ccc;
+  border-radius: 12px;
+  font-size: 16px;
+  color: #999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  box-sizing: border-box;
+}
+
+/* ---------- 강사 카드 전용 ---------- */
+.instructor-card {
+  width: 180px;
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 1px 8px rgba(0, 0, 0, 0.06);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.instructor-card:hover {
+  transform: translateY(-4px);
+}
+
+/* 프로필 이미지 영역 (배경 + 정중앙 정렬) */
+.instructor-profile-wrapper {
+  width: 100%;
+  height: 180px;
+  background: #f0f0f0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* 프로필 원형 이미지 */
+.instructor-profile {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+/* 프로필 아래 닉네임 */
+.instructor-content {
+  padding: 12px;
+  text-align: center;
+}
+
+.instructor-nickname {
+  font-weight: 600;
+  font-size: 16px;
+  color: #333;
+  margin-top: 8px;
+}
+
+/* ---------- 강의 카드 (메인페이지 스타일 그대로) ---------- */
+
+/* 강의 카드 한 장 */
+.card {
+  width: 240px;
+  border-radius: 12px;
+  background-color: #fff;
+  box-shadow: 0 1px 8px rgba(0, 0, 0, 0.06);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  transition: transform 0.2s ease;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+}
+
+/* 썸네일 영역 */
+.thumbnail-wrapper {
+  width: 100%;
+  height: 160px;
+  background: #f0f0f0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* 썸네일 이미지 */
+.thumbnail {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+}
+
+/* 카드 내부 콘텐츠 */
+.card-content {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+/* 강의 제목 */
+.card-content .title {
+  font-weight: 600;
+  font-size: 15px;
+  color: #333;
+  line-height: 1.3;
+}
+
+/* 강의 가격 */
+.card-content .price {
+  font-weight: 700;
+  color: #5c3df3;
+  font-size: 14px;
+}

--- a/client/src/components/pages/search/search.tsx
+++ b/client/src/components/pages/search/search.tsx
@@ -1,0 +1,123 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import './search.css';
+
+/* ---------- 타입 ---------- */
+interface Lecture {
+  id: number;
+  title: string;
+  price: number | string;
+  thumbnail: string;
+  category?: string; // 서비스 쿼리에 category 포함 권장
+}
+interface Instructor {
+  id: number;
+  nickname: string;
+  profile_image: string;
+  lectures: Lecture[];
+}
+
+/* ---------- 상수 ---------- */
+const categories = ['전체', '교육', '개발', '음악', '요리', '운동', '글쓰기', '예술'];
+
+const SearchPage: React.FC = () => {
+  const navigate = useNavigate();
+  const [params] = useSearchParams();
+
+  const [lectures, setLectures] = useState<Lecture[]>([]);
+  const [matchedInst, setMatchedInst] = useState<Instructor | null>(null);
+  const [selectedCat, setSelectedCat] = useState('전체');
+
+  /* 검색 API 호출 */
+  useEffect(() => {
+    const q = params.get('q')?.trim() || '';
+    if (!q) return;
+
+    const fetch = async () => {
+      try {
+        const url = `${import.meta.env.VITE_API_URL}/search?q=${encodeURIComponent(q)}&page=1`;
+        const { data } = await axios.get(url);
+        setLectures(data.lectures || []);
+        setMatchedInst(data.matched_instructor || null);
+      } catch (err) {
+        console.error('검색 실패:', err);
+      }
+    };
+    fetch();
+  }, [params]);
+
+  /* 카테고리 필터링 (강의에만 적용) */
+  const displayedLectures =
+    selectedCat === '전체' ? lectures : lectures.filter((l) => l.category === selectedCat);
+
+  const fmtPrice = (p: number | string) =>
+    isNaN(Number(p)) ? String(p) : Number(p).toLocaleString();
+
+  return (
+    <div className="search-wrapper">
+      {/* ===== 크리에이터 섹션 ===== */}
+      {matchedInst && (
+        <>
+          <h2 className="search-title">크리에이터</h2>
+          <div className="creator-grid">
+            <div
+              className="instructor-card"
+              onClick={() => navigate(`/instructors/${matchedInst.id}`)}
+            >
+              <div className="instructor-profile-wrapper">
+                <img
+                  className="instructor-profile"
+                  src={matchedInst.profile_image}
+                  alt={matchedInst.nickname}
+                />
+              </div>
+              <div className="instructor-content">
+                <div className="instructor-nickname">{matchedInst.nickname}</div>
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* ===== 카테고리 필터 (강의 전용) ===== */}
+      <div className="search-category-filter">
+        {categories.map((c) => (
+          <button
+            key={c}
+            className={`category-btn ${selectedCat === c ? 'active' : ''}`}
+            onClick={() => setSelectedCat(c)}
+          >
+            {c}
+          </button>
+        ))}
+      </div>
+
+      {/* ===== 강의 결과 섹션 ===== */}
+      <h2 className="search-title">강의</h2>
+      {displayedLectures.length ? (
+        <div className="lecture-grid">
+          {displayedLectures.map((lec) => (
+            <div
+              key={lec.id}
+              className="card"
+              onClick={() => navigate(`/lectures/${lec.id}/apply`)}
+            >
+              <div className="thumbnail-wrapper">
+                <img className="thumbnail" src={lec.thumbnail} alt={lec.title} />
+              </div>
+              <div className="card-content">
+                <div className="title">{lec.title}</div>
+                <div className="price">{fmtPrice(lec.price)}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="empty-search">검색 결과가 없습니다.</div>
+      )}
+    </div>
+  );
+};
+
+export default SearchPage;

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -14,6 +14,7 @@ import VideoListPage from '@/components/pages/VideoListPage';
 import BoardPostDetailPage from '@/components/pages/boardPostDetail';
 import LecturePage from '@/components/pages/lectureApply';
 import InstructorInfoPage from '@/components/pages/instructorInfo';
+import SearchPage from '@/components/pages/search/search';
 
 export const AppRoutes = () => {
   return (
@@ -34,6 +35,7 @@ export const AppRoutes = () => {
         <Route path="streamingpage" element={<StreamingPage />} />
         <Route path="lectures/:id/apply" element={<LecturePage />} />
         <Route path="instructor-info" element={<InstructorInfoPage />} />
+        <Route path="search" element={<SearchPage />} />
       </Route>
     </Routes>
   );


### PR DESCRIPTION
<!--
머지 제목은 항상 다음과 같은 규칙을 지킨다.
[날짜] 해당 Merge와 관련된 큰 제목
ex) [240806] 학습한 강의 수 저장 기능
머지 내용은 아래 템플릿을 복사해서 사용한다.
-->

### PR 타입

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 프론트엔드 검색 페이지(SearchPage) UI/기능 구현
  - 크리에이터(강사) 검색 결과 섹션 추가
  - 카테고리 필터(전체/교육/개발/음악 등) 추가
  - 강의 검색 결과 섹션 구현 (기존 강의 카드 UI 재사용)
- 백엔드 검색 API 연동 완료(`/search?q=검색어&page=1`)
- search.css 통합 스타일 적용 완료
### 전달 사항
